### PR TITLE
Add additive method expansion (--expand-methods) and compression-planning prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ akaidoo sale_stock -c odoo.conf -u ~/OpenUpgrade -o migration.md
 
 # Prune specific large methods
 akaidoo sale_stock -c odoo.conf --prune-methods sale.order._compute_amounts -x
+
+# Additively expand only key methods (and their same-class callees)
+akaidoo account -c odoo.conf --shrink=hard --expand-methods account.move._post,account.move.line._reconcile -x
+
+# Emit a planning prompt for a cheap long-context model (Gemini Flash, etc.)
+akaidoo account -c odoo.conf --agent --emit-compress-prompt --compress-task "Investigate invoice posting tax mismatch" -o .akaidoo/context/background.md
 ```
 
 ## Shrink Modes
@@ -203,6 +209,22 @@ Path: .akaidoo/context/background.md
 ```
 
 **Use case**: AI coding assistants (Claude, Cursor) that have file reading capabilities.
+
+
+### Two-Pass Compression Workflow (Cheap Planner LLM + Coding Agent)
+
+For very large contexts, use a cheap large-window model as a *planner* first, then run
+akaidoo again with the returned filters:
+
+1. Generate agent context with planning prompt:
+   `akaidoo account --agent --emit-compress-prompt --compress-task "..." -o .akaidoo/context/background.md`
+2. Ask the planner model to return JSON with `exclude_addons`, `rm_expand`,
+   `expand_models`, and `expand_methods`.
+3. Re-run akaidoo with those options, especially `--expand-methods` to keep large files
+   slim while preserving critical logic paths additively.
+
+`--expand-methods` is additive (it does not prune globally): only the selected methods
+and their same-class callees are expanded when shrinking is active.
 
 ## MCP Server
 

--- a/src/akaidoo/cli.py
+++ b/src/akaidoo/cli.py
@@ -482,6 +482,24 @@ def akaidoo_command_entrypoint(
         "-P",
         help="Comma-separated list of methods to force prune (e.g. 'Model.method').",
     ),
+    expand_methods_str: Optional[str] = typer.Option(
+        None,
+        "--expand-methods",
+        "-M",
+        help="Comma-separated list of methods to force expand additively (e.g. 'account.move._post'). Called methods in the same class are auto-expanded.",
+    ),
+    compress_task: Optional[str] = typer.Option(
+        None,
+        "--compress-task",
+        help="Task description used to generate a two-pass compression prompt for a cheap planning LLM.",
+        show_default=False,
+    ),
+    emit_compress_prompt: bool = typer.Option(
+        False,
+        "--emit-compress-prompt",
+        help="Print a JSON-oriented prompt template for a cheap LLM to suggest akaidoo filtering options.",
+        show_default=False,
+    ),
     session: bool = typer.Option(
         False,
         "--session",
@@ -536,6 +554,7 @@ def akaidoo_command_entrypoint(
         add_expand_str=add_expand_str,
         rm_expand_str=rm_expand_str,
         prune_methods_str=prune_methods_str,
+        expand_methods_str=expand_methods_str,
         skip_expanded=agent_mode,
         context_budget=budget_chars,
     )
@@ -901,6 +920,24 @@ This map shows the active scope. "Pruned" modules are hidden to save focus.
                     typer.echo(
                         f"| {entry['type']} | {entry['path']} | {start}-{entry['end']} |"
                     )
+
+    if emit_compress_prompt:
+        task_line = compress_task or "<describe your implementation/debugging objective>"
+        typer.echo(typer.style("\n## 4. COMPRESSION PLANNING PROMPT (for cheap long-context model)", bold=True))
+        typer.echo("Use the template below with Gemini Flash / similar model and apply the returned options in a second akaidoo run.")
+        typer.echo("```text")
+        typer.echo("You are optimizing Akaidoo context for a constrained agentic window.")
+        typer.echo(f"Task: {task_line}")
+        typer.echo("Budget: Keep preloaded context <= 150k tokens (or user target).")
+        typer.echo("Rules:")
+        typer.echo("1) Prefer removing irrelevant modules/files/models first.")
+        typer.echo("2) For large files, prefer additive method selection over prune lists.")
+        typer.echo("3) When selecting a method, include likely same-class callees transitively.")
+        typer.echo("4) Keep critical business flows and traceback paths safe; avoid risky removals.")
+        typer.echo("Return STRICT JSON with keys:")
+        typer.echo('{"exclude_addons": [], "rm_expand": [], "expand_models": [], "expand_methods": [], "notes": ""}')
+        typer.echo("Do not include markdown.")
+        typer.echo("```")
 
 
 def find_pr_commits_after_target(

--- a/src/akaidoo/context.py
+++ b/src/akaidoo/context.py
@@ -285,25 +285,29 @@ def _parse_expansion_options(
     add_expand_str: Optional[str],
     rm_expand_str: Optional[str],
     prune_methods_str: Optional[str],
+    expand_methods_str: Optional[str],
     auto_expand: bool,
-) -> tuple[Set[str], Set[str], Set[str], Set[str], Set[str], bool]:
+) -> tuple[Set[str], Set[str], Set[str], Set[str], Set[str], Set[str], bool]:
     """
     Parse and validate expansion-related CLI options.
 
     Returns:
         (expand_models_set, focus_models_set, add_expand_set,
-         rm_expand_set, prune_methods_set, auto_expand)
+         rm_expand_set, prune_methods_set, expand_methods_set, auto_expand)
     """
     expand_models_set: Set[str] = set()
     focus_models_set: Set[str] = set()
     add_expand_set: Set[str] = set()
     rm_expand_set: Set[str] = set()
     prune_methods_set: Set[str] = set()
+    expand_methods_set: Set[str] = set()
 
     if rm_expand_str:
         rm_expand_set = {m.strip() for m in rm_expand_str.split(",")}
     if prune_methods_str:
-        prune_methods_set = {m.strip() for m in prune_methods_str.split(",")}
+        prune_methods_set = {m.strip() for m in prune_methods_str.split(",") if m.strip()}
+    if expand_methods_str:
+        expand_methods_set = {m.strip() for m in expand_methods_str.split(",") if m.strip()}
 
     if expand_models_str:
         # Explicit mode: disables auto-expand
@@ -321,6 +325,7 @@ def _parse_expansion_options(
         add_expand_set,
         rm_expand_set,
         prune_methods_set,
+        expand_methods_set,
         auto_expand,
     )
 
@@ -572,6 +577,7 @@ def resolve_akaidoo_context(
     add_expand_str: Optional[str] = None,
     rm_expand_str: Optional[str] = None,
     prune_methods_str: Optional[str] = None,
+    expand_methods_str: Optional[str] = None,
     skip_expanded: bool = False,
     context_budget: Optional[int] = None,
 ) -> AkaidooContext:
@@ -603,12 +609,14 @@ def resolve_akaidoo_context(
         add_expand_set,
         rm_expand_set,
         prune_methods_set,
+        expand_methods_set,
         auto_expand,
     ) = _parse_expansion_options(
         expand_models_str,
         add_expand_str,
         rm_expand_str,
         prune_methods_str,
+        expand_methods_str,
         True,
     )
 
@@ -868,6 +876,7 @@ def resolve_akaidoo_context(
                 expand_models_set=expand_models_set,
                 relevant_models=relevant_models,
                 prune_methods=prune_methods_set,
+                expand_methods=expand_methods_set,
                 skip_expanded=skip_expanded,
             )
             # Merge scan results into the main collections
@@ -960,6 +969,7 @@ def resolve_akaidoo_context(
                 add_expand_str=add_expand_str,
                 rm_expand_str=rm_expand_str,
                 prune_methods_str=prune_methods_str,
+                expand_methods_str=expand_methods_str,
                 skip_expanded=skip_expanded,
                 context_budget=None,  # Don't recurse with budget
             )

--- a/src/akaidoo/scanner.py
+++ b/src/akaidoo/scanner.py
@@ -61,6 +61,7 @@ def scan_addon_files(
     expand_models_set: Optional[Set[str]] = None,
     relevant_models: Optional[Set[str]] = None,
     prune_methods: Optional[Set[str]] = None,
+    expand_methods: Optional[Set[str]] = None,
     skip_expanded: bool = False,
 ) -> ScanResult:
     """
@@ -80,6 +81,7 @@ def scan_addon_files(
     relevant_models = relevant_models or set()
     excluded_addons = excluded_addons or set()
     prune_methods = prune_methods or set()
+    expand_methods = expand_methods or set()
 
     scan_roots: List[str] = []
     if "model" in includes:
@@ -293,6 +295,7 @@ def scan_addon_files(
                                 ),
                                 relevant_models=relevant_models,
                                 prune_methods=prune_methods,
+                                expand_methods=expand_methods,
                                 header_path=str(header_path),
                                 skip_expanded_content=skip_expanded,
                                 expanded_shrink_level=expanded_shrink_level,

--- a/src/akaidoo/service.py
+++ b/src/akaidoo/service.py
@@ -44,6 +44,7 @@ class ContextOptions:
     # Shrink and prune modes
     shrink_mode: str = "soft"
     prune_methods_str: Optional[str] = None
+    expand_methods_str: Optional[str] = None
 
     # Model expansion
     expand_models_str: Optional[str] = None
@@ -88,6 +89,7 @@ class AkaidooService:
         no_exclude_addons_str: Optional[str] = None,
         shrink_mode: str = "soft",
         prune_methods_str: Optional[str] = None,
+        expand_methods_str: Optional[str] = None,
         expand_models_str: Optional[str] = None,
         add_expand_str: Optional[str] = None,
         rm_expand_str: Optional[str] = None,
@@ -112,6 +114,7 @@ class AkaidooService:
             no_exclude_addons_str: Addons to force include
             shrink_mode: none, soft, medium, hard, max
             prune_methods_str: Methods to prune (e.g., "Model.method")
+            expand_methods_str: Methods to force expand (e.g., "model.name._method")
             expand_models_str: Models to fully expand
             auto_expand: Auto-expand high-score models
             add_expand_str: Add models to auto-expand set
@@ -139,6 +142,7 @@ class AkaidooService:
             no_exclude_addons_str=no_exclude_addons_str,
             shrink_mode=shrink_mode,
             prune_methods_str=prune_methods_str,
+            expand_methods_str=expand_methods_str,
             expand_models_str=expand_models_str,
             add_expand_str=add_expand_str,
             rm_expand_str=rm_expand_str,
@@ -172,6 +176,7 @@ class AkaidooService:
             no_exclude_addons_str=options.no_exclude_addons_str,
             shrink_mode=options.shrink_mode,
             prune_methods_str=options.prune_methods_str,
+            expand_methods_str=options.expand_methods_str,
             expand_models_str=options.expand_models_str,
             add_expand_str=options.add_expand_str,
             rm_expand_str=options.rm_expand_str,

--- a/src/akaidoo/shrinker.py
+++ b/src/akaidoo/shrinker.py
@@ -203,6 +203,71 @@ def _get_field_info(node, code_bytes: bytes) -> Dict:
     return info
 
 
+def _parse_expand_methods_map(expand_methods: Set[str]) -> Dict[str, Set[str]]:
+    """Parse `model.method` selectors into a model -> method names map."""
+    mapped: Dict[str, Set[str]] = {}
+    for item in expand_methods:
+        token = item.strip()
+        if not token or "." not in token:
+            continue
+        model_name, method_name = token.rsplit(".", 1)
+        if not model_name or not method_name:
+            continue
+        mapped.setdefault(model_name, set()).add(method_name)
+    return mapped
+
+
+def _collect_called_methods(function_text: str) -> Set[str]:
+    """Extract likely intra-class method calls from a function body."""
+    calls = set(re.findall(r"\bself\.([A-Za-z_][A-Za-z0-9_]*)\s*\(", function_text))
+    calls.update(re.findall(r"\b(?:super\(\)\.)([A-Za-z_][A-Za-z0-9_]*)\s*\(", function_text))
+    return calls
+
+
+def _compute_method_expansion_closure(
+    class_node,
+    code_bytes: bytes,
+    seed_methods: Set[str],
+) -> Set[str]:
+    """Expand selected methods transitively through same-class calls."""
+    if not seed_methods:
+        return set()
+
+    body_node = class_node.child_by_field_name("body")
+    if not body_node:
+        return set()
+
+    graph: Dict[str, Set[str]] = {}
+    for child in body_node.children:
+        func_def = None
+        if child.type == "function_definition":
+            func_def = child
+        elif child.type == "decorated_definition":
+            definition = child.child_by_field_name("definition")
+            if definition and definition.type == "function_definition":
+                func_def = definition
+        if not func_def:
+            continue
+
+        name_node = func_def.child_by_field_name("name")
+        if not name_node:
+            continue
+        method_name = code_bytes[name_node.start_byte : name_node.end_byte].decode("utf-8")
+        fn_text = code_bytes[child.start_byte : child.end_byte].decode("utf-8")
+        graph[method_name] = _collect_called_methods(fn_text)
+
+    closure = set(seed_methods)
+    stack = list(seed_methods)
+    while stack:
+        current = stack.pop()
+        for called in graph.get(current, set()):
+            if called in graph and called not in closure:
+                closure.add(called)
+                stack.append(called)
+
+    return closure
+
+
 def shrink_python_file(
     path: str,
     aggressive: bool = False,
@@ -212,6 +277,7 @@ def shrink_python_file(
     shrink_level: Optional[str] = None,
     relevant_models: Optional[Set[str]] = None,
     prune_methods: Optional[Set[str]] = None,
+    expand_methods: Optional[Set[str]] = None,
     header_path: Optional[str] = None,
     skip_expanded_content: bool = False,
     expanded_shrink_level: Optional[str] = None,
@@ -246,7 +312,7 @@ def shrink_python_file(
     # If prune_methods is set, we MUST parse.
     # If header_path is set (implies we want context navigation), we MUST parse.
     # So basically always parse unless simple 'none' with no extras.
-    if shrink_level == "none" and not prune_methods and not skip_expanded_content:
+    if shrink_level == "none" and not prune_methods and not expand_methods and not skip_expanded_content:
         # But wait, header logic is inside loop. If we skip parsing, we miss headers.
         # Assuming we always want context headers if header_path is provided.
         if not header_path:
@@ -261,6 +327,8 @@ def shrink_python_file(
     expand_models = expand_models or set()
     relevant_models = relevant_models or set()
     prune_methods = prune_methods or set()
+    expand_methods = expand_methods or set()
+    expand_methods_map = _parse_expand_methods_map(expand_methods)
     actually_expanded_models = set()
     expanded_locations: Dict[str, List[Tuple[int, int, str]]] = {}
     model_shrink_levels: Dict[str, str] = {}  # Track effective shrink level per model
@@ -289,7 +357,11 @@ def shrink_python_file(
         return line.strip()
 
     def process_function(
-        node, indent="", context_models: Set[str] = None, override_level: str = None
+        node,
+        indent="",
+        context_models: Set[str] = None,
+        override_level: str = None,
+        expanded_method_names: Optional[Set[str]] = None,
     ):
         effective_level = override_level if override_level else shrink_level
 
@@ -301,21 +373,28 @@ def shrink_python_file(
             else:
                 return
 
+        func_name = None
+        func_name_node = func_def_node.child_by_field_name("name")
+        if func_name_node:
+            func_name = code_bytes[
+                func_name_node.start_byte : func_name_node.end_byte
+            ].decode("utf-8")
+
         should_prune_specifically = False
-        if context_models:
-            func_name_node = func_def_node.child_by_field_name("name")
-            if func_name_node:
-                func_name = code_bytes[
-                    func_name_node.start_byte : func_name_node.end_byte
-                ].decode("utf-8")
-                for m in context_models:
-                    if f"{m}.{func_name}" in prune_methods:
-                        should_prune_specifically = True
-                        break
+        should_expand_specifically = bool(
+            func_name and expanded_method_names and func_name in expanded_method_names
+        )
+
+        if context_models and func_name:
+            for m in context_models:
+                if f"{m}.{func_name}" in prune_methods:
+                    should_prune_specifically = True
+                    break
 
         if (
             effective_level in ("hard", "max", "prune")
             and not should_prune_specifically
+            and not should_expand_specifically
         ):
             return
 
@@ -334,7 +413,7 @@ def shrink_python_file(
             shrunken_parts.append(f"{indent}    pass  # pruned by request")
             return
 
-        if effective_level == "soft":
+        if effective_level == "soft" and not should_expand_specifically:
             for line in header_text.splitlines():
                 stripped_line = line.strip()
                 if stripped_line:
@@ -367,6 +446,13 @@ def shrink_python_file(
                 current_model_index += 1
 
             should_expand = any(m in expand_models for m in model_names)
+
+            selected_methods_for_class: Set[str] = set()
+            for model_name in model_names:
+                selected_methods_for_class.update(expand_methods_map.get(model_name, set()))
+            expanded_method_names = _compute_method_expansion_closure(
+                node, code_bytes, selected_methods_for_class
+            )
 
             has_pruned_methods = False
             for m in model_names:
@@ -591,6 +677,7 @@ def shrink_python_file(
                                 indent="    ",
                                 context_models=model_names,
                                 override_level=effective_level,
+                                expanded_method_names=expanded_method_names,
                             )
 
                     if effective_level == "max":
@@ -662,6 +749,12 @@ def main():
         help="Comma separated methods to prune (Model.method).",
     )
     cli_parser.add_argument(
+        "-M",
+        "--expand-methods",
+        type=str,
+        help="Comma separated methods to force expand (model.name._method).",
+    )
+    cli_parser.add_argument(
         "-H", "--header-path", type=str, help="File path for headers."
     )
     cli_parser.add_argument(
@@ -672,6 +765,9 @@ def main():
 
     expand_set = set(args.expand.split(",")) if args.expand else set()
     prune_set = set(args.prune_methods.split(",")) if args.prune_methods else set()
+    expand_set_methods = (
+        set(args.expand_methods.split(",")) if args.expand_methods else set()
+    )
 
     try:
         result = shrink_python_file(
@@ -680,6 +776,7 @@ def main():
             shrink_level=args.shrink_level,
             expand_models=expand_set,
             prune_methods=prune_set,
+            expand_methods=expand_set_methods,
             header_path=args.header_path,
             skip_expanded_content=args.skip_expanded,
         )

--- a/tests/test_shrinker.py
+++ b/tests/test_shrinker.py
@@ -100,3 +100,68 @@ class MyModel(models.Model):
 
     # Check One2many
     assert "lines_ids = fields.One2many('my.line', 'model_id')" in content
+
+
+def test_expand_methods_additive_with_transitive_calls(tmp_path: Path):
+    file_path = tmp_path / "expand_methods.py"
+    file_path.write_text(
+        """
+from odoo import models
+
+class AccountMove(models.Model):
+    _name = "account.move"
+
+    def _post(self):
+        self._check_balanced()
+        return self._synchronize()
+
+    def _check_balanced(self):
+        return True
+
+    def _synchronize(self):
+        self._finalize()
+        return True
+
+    def _finalize(self):
+        return True
+
+    def _noise(self):
+        return "ignored"
+"""
+    )
+
+    result = shrink_python_file(
+        str(file_path),
+        shrink_level="hard",
+        expand_methods={"account.move._post"},
+    )
+
+    content = result.content
+    assert "def _post(self):" in content
+    assert "def _check_balanced(self):" in content
+    assert "def _synchronize(self):" in content
+    assert "def _finalize(self):" in content
+    assert "def _noise(self):" not in content
+
+
+def test_expand_methods_ignored_for_other_models(tmp_path: Path):
+    file_path = tmp_path / "expand_methods_other.py"
+    file_path.write_text(
+        """
+from odoo import models
+
+class SaleOrder(models.Model):
+    _name = "sale.order"
+
+    def action_confirm(self):
+        return True
+"""
+    )
+
+    result = shrink_python_file(
+        str(file_path),
+        shrink_level="hard",
+        expand_methods={"account.move._post"},
+    )
+
+    assert "def action_confirm(self):" not in result.content


### PR DESCRIPTION
### Motivation
- Reduce Akaidoo context size more effectively by allowing an additive way to include only critical methods (and their call-closure) from very large files instead of brittle method pruning. 
- Enable a cheap long-context planner LLM workflow to suggest filters (modules/models/methods) so akaidoo can produce a compact, relevant agentic context within tight token budgets. 

### Description
- Added CLI options `--expand-methods/-M` to request additive expansion of specific `model.method` selectors, and `--emit-compress-prompt` / `--compress-task` to emit a strict JSON-oriented planning prompt for a cheap planner model. 
- Threaded the new `expand_methods` option through the service, context resolution, and scanner so it propagates into the shrinker during scanning. 
- Implemented method-level expansion in the shrinker: `_parse_expand_methods_map`, `_collect_called_methods`, and `_compute_method_expansion_closure` compute a transitive same-class callee closure so selected methods (and their intra-class callees) are kept even under aggressive shrink levels. 
- Modified `process_function` and class handling in `shrinker.py` to respect `expand_methods` so method expansion is additive (keeps only selected methods + closure) while preserving existing prune mechanics. 
- Updated `README.md` with usage examples and a Two-Pass Compression Workflow section describing the planner+agent flow, and added tests exercising the additive method expansion behavior. 

### Testing
- Ran unit tests for the shrinker with `PYTHONPATH=src pytest -q tests/test_shrinker.py`, which completed successfully (`5 passed`). 
- Verified all module sources compile with `python -m py_compile src/akaidoo/*.py` with no errors. 
- Verified CLI help invocation with `PYTHONPATH=src python -m akaidoo.cli --help` to confirm new options are exposed and documented.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adace3086c83318cf07811bbdf3552)